### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ sudo tar xpf Tegra_Linux_Sample-Root-Filesystem_r39.2.0_aarch64.tbz2 -C Linux_fo
 
 ```
 cd Linux_for_Tegra/source/
-./source_sync.sh -t jetson_39.2
+./source_sync.sh -t jetson_39.2.0
 ```
 
 4. Clone this repo and overwrite the original source code.


### PR DESCRIPTION
fix ./source_sync.sh -t jetson_39.2.0

Claude code log
```
● Confirmed — here's the full root cause chain:

  The bug is a tag-name typo in Seeed-Studio's own readme.

  Their instructions literally say:
  ./source_sync.sh -t jetson_39.2
  But that tag does not exist on NVIDIA's git servers — I verified against hwpm's remote tags, only jetson_39.2.0 and jetson_39.2_GA exist, not bare jetson_39.2.

  Here's why that silently breaks everything instead of failing loudly:
  - source_sync.sh's DownloadAndSync() function does git fetch, then git checkout -b mybranch_<timestamp> "${TAG}". I reproduced this by hand — git checkout -b test jetson_39.2 fails with fatal: 'jetson_39.2' is not a commit.
  - When that checkout fails, the function just echos "Failed to checkout tag jetson_39.2 for X" and return 1 — it does not abort the script. The main loop only exits early if you pass -e (exit-on-error), which the Seeed readme doesn't tell you to use. So the script
  barrels through all ~40 repos, each one silently staying on whatever stale branch it already had, and reports the failures buried in scroll-back output rather than a clear error.

  That's exactly the mismatched-version state I found: hwpm/nvidia-oot stuck on l4t/l4t-r36.2, nvgpu/unifiedgpudisp on l4t/l4t-r38.2, nvethernetrm/nvdisplay on l4t/l4t-35.5.0, kernel-noble on an r38.2 branch — none advanced to r39.2.
```